### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: python
+python: 2.7
+sudo: false
+cache:
+  directories:
+  - eggs
+env:
+  matrix:
+    - PLONE_VERSION=4.3
+    - PLONE_VERSION=5.0
+    - PLONE_VERSION=5.1
+matrix:
+  allow_failures:
+    - python: 2.7
+      env: PLONE_VERSION=5.0
+    - python: 2.7
+      env: PLONE_VERSION=5.1
+install:
+  - sed -ie "s#test-4.3#test-$PLONE_VERSION#" buildout.cfg
+  - sed -ie "s#versions-4.3#versions-$PLONE_VERSION#" buildout.cfg
+  - pip install -r requirements.txt
+  - buildout annotate
+  - buildout
+script:
+  - bin/test

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,0 +1,16 @@
+[buildout]
+extends =
+    https://raw.github.com/collective/buildout.plonetest/master/test-4.3.x.cfg
+    https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
+
+package-name = wildcard.lockdown
+package-extras = [test]
+
+parts +=
+    createcoverage
+
+[versions]
+# use latest version of coverage
+coverage =
+setuptools = 33.1.1
+zc.buildout = 2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+setuptools==33.1.1
+zc.buildout==2.8.0

--- a/wildcard/lockdown/tests/test_conditions.py
+++ b/wildcard/lockdown/tests/test_conditions.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 from wildcard.lockdown.testing import Lockdown_FUNCTIONAL_TESTING
 from wildcard.lockdown import CommitChecker
 from wildcard.lockdown import addCommitCondition

--- a/wildcard/lockdown/tests/test_lockdown.py
+++ b/wildcard/lockdown/tests/test_lockdown.py
@@ -5,7 +5,7 @@ from wildcard.lockdown.testing import browserLogin
 from wildcard.lockdown.testing import createObject
 from plone.testing.z2 import Browser
 import transaction
-import unittest2 as unittest
+import unittest
 from wildcard.lockdown.testing import Lockdown_FUNCTIONAL_TESTING
 
 

--- a/wildcard/lockdown/tests/test_registry.py
+++ b/wildcard/lockdown/tests/test_registry.py
@@ -1,6 +1,6 @@
 from zope.interface import alsoProvides
 
-import unittest2 as unittest
+import unittest
 
 from zope.component import getMultiAdapter
 from zope.component import getUtility


### PR DESCRIPTION
It currently fails on 5.0 and 5.1 due to not being able to create folders... is there a generic way to do that for both 4.3 and 5.1?

@rafaelbco as you are the interested one here... do you need 4.3 compatibility as well or 5.x would be enough? Then we could install unconditionally p.a.contenttypes.